### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Achievement and Assessment Institute/KiteStudentPortal.pkg.recipe
+++ b/Achievement and Assessment Institute/KiteStudentPortal.pkg.recipe
@@ -12,8 +12,6 @@
 	<dict>
 		<key>APP_FILENAME</key>
 		<string>Kite Student Portal</string>
-		<key>BUNDLE_ID</key>
-		<string>org.ats.kitestudentportal</string>
 		<key>NAME</key>
 		<string>KiteStudentPortal</string>
 	</dict>

--- a/Adrian Granados/WiFi Explorer Pro.pkg.recipe
+++ b/Adrian Granados/WiFi Explorer Pro.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.WiFiExplorerPro</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.adriangranados.wifiexplorerpro</string>
 		<key>NAME</key>
 		<string>WiFi Explorer Pro</string>
 	</dict>

--- a/DWAB Technology/VEX Tournament Manager.pkg.recipe
+++ b/DWAB Technology/VEX Tournament Manager.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.VEXTournamentManager</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>VEX Tournament Manager</string>
 		<key>NAME</key>
 		<string>VEX Tournament Manager</string>
 	</dict>

--- a/Decisive Tactics/Serial.pkg.recipe
+++ b/Decisive Tactics/Serial.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.Serial</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.decisivetactics.serial.direct</string>
 		<key>NAME</key>
 		<string>Serial</string>
 	</dict>

--- a/Guilherme Rambo/AppleEvents.pkg.recipe
+++ b/Guilherme Rambo/AppleEvents.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.AppleEvents</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>br.com.guilhermerambo.Apple-Events</string>
 		<key>NAME</key>
 		<string>Apple Events</string>
 	</dict>

--- a/Huang JianYun/TunesKit M4V Converter.pkg.recipe
+++ b/Huang JianYun/TunesKit M4V Converter.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.TunesKitM4VConverter</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.TunesKit.TunesKitM4VConverter</string>
 		<key>NAME</key>
 		<string>TunesKit M4V Converter</string>
 	</dict>

--- a/Jakob Egger/Table Tool.pkg.recipe
+++ b/Jakob Egger/Table Tool.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.TableTool</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>at.eggerapps.tabletool</string>
 		<key>NAME</key>
 		<string>Table Tool</string>
 	</dict>

--- a/Kuta Software/Infinite Algebra 1.pkg.recipe
+++ b/Kuta Software/Infinite Algebra 1.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.InfiniteAlgebra1</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.kutasoftware.InfiniteAlgebra1</string>
 		<key>NAME</key>
 		<string>Infinite Algebra 1</string>
 	</dict>

--- a/Kuta Software/Infinite Algebra 2.pkg.recipe
+++ b/Kuta Software/Infinite Algebra 2.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.InfiniteAlgebra2</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.kutasoftware.InfiniteAlgebra2</string>
 		<key>NAME</key>
 		<string>Infinite Algebra 2</string>
 	</dict>

--- a/Kuta Software/Infinite Calculus.pkg.recipe
+++ b/Kuta Software/Infinite Calculus.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.InfiniteCalculus</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.kutasoftware.InfiniteCalculus</string>
 		<key>NAME</key>
 		<string>Infinite Calculus</string>
 	</dict>

--- a/Kuta Software/Infinite Geometry.pkg.recipe
+++ b/Kuta Software/Infinite Geometry.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.InfiniteGeometry</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.kutasoftware.InfiniteGeometry</string>
 		<key>NAME</key>
 		<string>Infinite Geometry</string>
 	</dict>

--- a/Kuta Software/Infinite Pre-Algebra.pkg.recipe
+++ b/Kuta Software/Infinite Pre-Algebra.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.InfinitePre-Algebra</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.kutasoftware.InfinitePreAlgebra</string>
 		<key>NAME</key>
 		<string>Infinite Pre-Algebra</string>
 	</dict>

--- a/Kuta Software/Infinite Precalculus.pkg.recipe
+++ b/Kuta Software/Infinite Precalculus.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.InfinitePrecalculus</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.kutasoftware.InfinitePrecalculus</string>
 		<key>NAME</key>
 		<string>Infinite Precalculus</string>
 	</dict>

--- a/Michael Herrmann/fman.pkg.recipe
+++ b/Michael Herrmann/fman.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.fman</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>io.fman.fman</string>
 		<key>NAME</key>
 		<string>fman</string>
 	</dict>

--- a/Nindi Gill/MacUserGenerator.pkg.recipe
+++ b/Nindi Gill/MacUserGenerator.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.MacUserGenerator</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.ninxsoft.MacUserGenerator</string>
 		<key>NAME</key>
 		<string>MacUserGenerator</string>
 	</dict>

--- a/Sonarr/Sonarr.pkg.recipe
+++ b/Sonarr/Sonarr.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.Sonarr</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.osx.sonarr.tv</string>
 		<key>NAME</key>
 		<string>Sonarr</string>
 	</dict>

--- a/Tran Ky Nam/aText.pkg.recipe
+++ b/Tran Ky Nam/aText.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.aText</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.trankynam.aText</string>
 		<key>NAME</key>
 		<string>aText</string>
 	</dict>

--- a/Vital Source Technologies/VitalSource Bookshelf.pkg.recipe
+++ b/Vital Source Technologies/VitalSource Bookshelf.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.macprince.pkg.VitalSourceBookshelf</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.vitalsource.Bookshelf</string>
 		<key>NAME</key>
 		<string>VitalSource Bookshelf</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Achievement and Assessment Institute/KiteStudentPortal.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Achievement\ and\ Assessment\ Institute/KiteStudentPortal.pkg.recipe
Processing repos/macprince-recipes/Achievement and Assessment Institute/KiteStudentPortal.pkg.recipe...
URLDownloader
{'Input': {'filename': 'KiteStudentPortal.dmg',
           'url': 'https://dynamiclearningmaps.org/download-kite-client-for-mac'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.KiteStudentPortal/downloads/KiteStudentPortal.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.KiteStudentPortal/downloads/KiteStudentPortal.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.KiteStudentPortal/downloads/KiteStudentPortal.dmg/Kite '
                         'Student Portal.app',
           'requirement': 'identifier "org.ats.kitestudentportal" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'BK4732M7XX'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.KiteStudentPortal/downloads/KiteStudentPortal.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.yQP7Ml/Kite Student Portal.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.yQP7Ml/Kite Student Portal.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.yQP7Ml/Kite Student Portal.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.KiteStudentPortal/downloads/KiteStudentPortal.dmg/Kite '
                               'Student Portal.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.KiteStudentPortal/downloads/KiteStudentPortal.dmg
Versioner: Found version 7.0.0 in file /private/tmp/dmg.oDzNLO/Kite Student Portal.app/Contents/Info.plist
{'Output': {'version': '7.0.0'}}
AppPkgCreator
{'Input': {'version': '7.0.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.KiteStudentPortal/downloads/KiteStudentPortal.dmg
AppPkgCreator: Using path '/private/tmp/dmg.k3e8P9/Kite Student Portal.app' matched from globbed '/private/tmp/dmg.k3e8P9/*.app'.
AppPkgCreator: BundleID: org.ats.kitestudentportal
AppPkgCreator: Copied /private/tmp/dmg.k3e8P9/Kite Student Portal.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.KiteStudentPortal/payload/Applications/Kite Student Portal.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.ats.kitestudentportal',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.KiteStudentPortal/Kite '
                                                                    'Student '
                                                                    'Portal-7.0.0.pkg',
                                                        'version': '7.0.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '7.0.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.KiteStudentPortal/receipts/KiteStudentPortal.pkg-receipt-20210213-234036.plist

The following packages were built:
    Identifier                 Version  Pkg Path                                                                                                       
    ----------                 -------  --------                                                                                                       
    org.ats.kitestudentportal  7.0.0    ~/Library/AutoPkg/Cache/com.github.macprince.pkg.KiteStudentPortal/Kite Student Portal-7.0.0.pkg  
```

## ✅ Adrian Granados/WiFi Explorer Pro.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Adrian\ Granados/WiFi\ Explorer\ Pro.pkg.recipe
Processing repos/macprince-recipes/Adrian Granados/WiFi Explorer Pro.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.adriangranados.com/appcasts/wifiexplorerprocast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 46
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.3.7
SparkleUpdateInfoProvider: Found URL https://www.intuitibits.com/appcasts/WiFiExplorerPro_2.3.7.zip
{'Output': {'url': 'https://www.intuitibits.com/appcasts/WiFiExplorerPro_2.3.7.zip',
            'version': '2.3.7'}}
URLDownloader
{'Input': {'filename': 'WiFi Explorer Pro-2.3.7.zip',
           'url': 'https://www.intuitibits.com/appcasts/WiFiExplorerPro_2.3.7.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/downloads/WiFi Explorer Pro-2.3.7.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/downloads/WiFi '
                        'Explorer Pro-2.3.7.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/downloads/WiFi '
                           'Explorer Pro-2.3.7.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/WiFi '
                               'Explorer Pro',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename WiFi Explorer Pro-2.3.7.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/downloads/WiFi Explorer Pro-2.3.7.zip to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/WiFi Explorer Pro
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/WiFi '
                         'Explorer Pro/WiFi Explorer Pro.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.adriangranados.wifiexplorerpro" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2B9R362QNU")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/WiFi Explorer Pro/WiFi Explorer Pro.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/WiFi Explorer Pro/WiFi Explorer Pro.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/WiFi Explorer Pro/WiFi Explorer Pro.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/WiFi '
                       'Explorer Pro/WiFi Explorer Pro.app',
           'version': '2.3.7'}}
AppPkgCreator: BundleID: com.adriangranados.wifiexplorerpro
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/WiFi Explorer Pro/WiFi Explorer Pro.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/payload/Applications/WiFi Explorer Pro.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.adriangranados.wifiexplorerpro',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/WiFi '
                                                                    'Explorer '
                                                                    'Pro-2.3.7.pkg',
                                                        'version': '2.3.7'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.3.7'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/receipts/WiFi Explorer Pro.pkg-receipt-20210213-234042.plist

The following packages were built:
    Identifier                          Version  Pkg Path                                                                                                   
    ----------                          -------  --------                                                                                                   
    com.adriangranados.wifiexplorerpro  2.3.7    ~/Library/AutoPkg/Cache/com.github.macprince.pkg.WiFiExplorerPro/WiFi Explorer Pro-2.3.7.pkg  
```

## ❌ DWAB Technology/VEX Tournament Manager.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/DWAB\ Technology/VEX\ Tournament\ Manager.pkg.recipe
Processing repos/macprince-recipes/DWAB Technology/VEX Tournament Manager.pkg.recipe...
URLDownloader
{'Input': {'filename': 'VEX Tournament Manager.dmg',
           'url': 'https://files.dwabtech.com/vextm/releases/2019_20.1.1/VEXTournamentManager-v2019_20.1.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VEXTournamentManager/downloads/VEX Tournament Manager.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.VEXTournamentManager/downloads/VEX '
                        'Tournament Manager.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.VEXTournamentManager/downloads/VEX '
                         'Tournament Manager.dmg/VEX Tournament Manager.app',
           'requirement': 'identifier "VEX Tournament Manager" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'V762UB84KY'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VEXTournamentManager/downloads/VEX Tournament Manager.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.BhNj5u/VEX Tournament Manager.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.BhNj5u/VEX Tournament Manager.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.BhNj5u/VEX Tournament Manager.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.VEXTournamentManager/downloads/VEX '
                               'Tournament Manager.dmg/VEX Tournament '
                               'Manager.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VEXTournamentManager/downloads/VEX Tournament Manager.dmg
Versioner: Found version 0.0.0 in file /private/tmp/dmg.wmubVB/VEX Tournament Manager.app/Contents/Info.plist
{'Output': {'version': '0.0.0'}}
AppPkgCreator
{'Input': {'version': '0.0.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VEXTournamentManager/downloads/VEX Tournament Manager.dmg
AppPkgCreator: Using path '/private/tmp/dmg.An2XIi/VEX Tournament Manager.app' matched from globbed '/private/tmp/dmg.An2XIi/*.app'.
AppPkgCreator: BundleID: VEX Tournament Manager
AppPkgCreator: Copied /private/tmp/dmg.An2XIi/VEX Tournament Manager.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VEXTournamentManager/payload/Applications/VEX Tournament Manager.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VEXTournamentManager/receipts/VEX Tournament Manager.pkg-receipt-20210213-234053.plist

The following recipes failed:
    repos/macprince-recipes/DWAB Technology/VEX Tournament Manager.pkg.recipe
        Error in com.github.macprince.pkg.VEXTournamentManager: Processor: AppPkgCreator: Error: Invalid package id

Nothing downloaded, packaged or imported.
```

## ✅ Decisive Tactics/Serial.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Decisive\ Tactics/Serial.pkg.recipe
Processing repos/macprince-recipes/Decisive Tactics/Serial.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(?P<DOWNLOAD_URL>https://.*\\.zip)',
           'url': 'https://www.decisivetactics.com/products/serial/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (DOWNLOAD_URL): https://download.decisivetactics.com/downloads/serial/Serial_2.0.7.zip
URLTextSearcher: Found matching text (match): https://download.decisivetactics.com/downloads/serial/Serial_2.0.7.zip
{'Output': {'DOWNLOAD_URL': 'https://download.decisivetactics.com/downloads/serial/Serial_2.0.7.zip',
            'match': 'https://download.decisivetactics.com/downloads/serial/Serial_2.0.7.zip'}}
URLDownloader
{'Input': {'filename': 'Serial.zip',
           'url': 'https://download.decisivetactics.com/downloads/serial/Serial_2.0.7.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/downloads/Serial.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/downloads/Serial.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/downloads/Serial.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/Serial',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Serial.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/downloads/Serial.zip to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/Serial
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/Serial/Serial.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.decisivetactics.serial.direct" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"8SG997W4XY")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/Serial/Serial.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/Serial/Serial.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/Serial/Serial.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/Serial/Serial.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 2.0.7 in file ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/Serial/Serial.app/Contents/Info.plist
{'Output': {'version': '2.0.7'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/Serial/Serial.app',
           'version': '2.0.7'}}
AppPkgCreator: BundleID: com.decisivetactics.serial.direct
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/Serial/Serial.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/payload/Applications/Serial.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.decisivetactics.serial.direct',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/Serial-2.0.7.pkg',
                                                        'version': '2.0.7'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.0.7'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/receipts/Serial.pkg-receipt-20210213-234101.plist

The following packages were built:
    Identifier                         Version  Pkg Path                                                                               
    ----------                         -------  --------                                                                               
    com.decisivetactics.serial.direct  2.0.7    ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Serial/Serial-2.0.7.pkg  
```

## ✅ Guilherme Rambo/AppleEvents.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Guilherme\ Rambo/AppleEvents.pkg.recipe
Processing repos/macprince-recipes/Guilherme Rambo/AppleEvents.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://github.com/insidegui/AppleEvents/raw/master/Releases/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 70
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.6
SparkleUpdateInfoProvider: Found URL https://github.com/insidegui/AppleEvents/releases/download/1.6/AppleEvents_v1.6.zip
{'Output': {'url': 'https://github.com/insidegui/AppleEvents/releases/download/1.6/AppleEvents_v1.6.zip',
            'version': '1.6'}}
URLDownloader
{'Input': {'filename': 'Apple Events-1.6.zip',
           'url': 'https://github.com/insidegui/AppleEvents/releases/download/1.6/AppleEvents_v1.6.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/downloads/Apple Events-1.6.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/downloads/Apple '
                        'Events-1.6.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/downloads/Apple '
                           'Events-1.6.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/Apple '
                               'Events',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Apple Events-1.6.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/downloads/Apple Events-1.6.zip to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/Apple Events
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/Apple '
                         'Events/Apple Events.app',
           'requirement': 'identifier "br.com.guilhermerambo.Apple-Events" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"8C7439RJLG"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/Apple Events/Apple Events.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/Apple Events/Apple Events.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/Apple Events/Apple Events.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/Apple '
                       'Events/Apple Events.app',
           'version': '1.6'}}
AppPkgCreator: BundleID: br.com.guilhermerambo.Apple-Events
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/Apple Events/Apple Events.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/payload/Applications/Apple Events.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'br.com.guilhermerambo.Apple-Events',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/Apple '
                                                                    'Events-1.6.pkg',
                                                        'version': '1.6'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.6'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/receipts/AppleEvents.pkg-receipt-20210213-234107.plist

The following packages were built:
    Identifier                          Version  Pkg Path                                                                                        
    ----------                          -------  --------                                                                                        
    br.com.guilhermerambo.Apple-Events  1.6      ~/Library/AutoPkg/Cache/com.github.macprince.pkg.AppleEvents/Apple Events-1.6.pkg  
```

## ✅ Huang JianYun/TunesKit M4V Converter.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Huang\ JianYun/TunesKit\ M4V\ Converter.pkg.recipe
Processing repos/macprince-recipes/Huang JianYun/TunesKit M4V Converter.pkg.recipe...
URLDownloader
{'Input': {'filename': 'TunesKit M4V Converter.dmg',
           'url': 'https://www.tuneskit.com/TunesKitforMac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TunesKitM4VConverter/downloads/TunesKit M4V Converter.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.TunesKitM4VConverter/downloads/TunesKit '
                        'M4V Converter.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.TunesKitM4VConverter/downloads/TunesKit '
                         'M4V Converter.dmg/TunesKit M4V Converter.app',
           'requirement': 'identifier "com.tuneskit.m4vconverter" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'B46DJ72P3B'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TunesKitM4VConverter/downloads/TunesKit M4V Converter.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.hg4iVz/TunesKit M4V Converter.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.hg4iVz/TunesKit M4V Converter.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.hg4iVz/TunesKit M4V Converter.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.TunesKitM4VConverter/downloads/TunesKit '
                               'M4V Converter.dmg/TunesKit M4V '
                               'Converter.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TunesKitM4VConverter/downloads/TunesKit M4V Converter.dmg
Versioner: Found version 5.1.0 in file /private/tmp/dmg.uG6vi1/TunesKit M4V Converter.app/Contents/Info.plist
{'Output': {'version': '5.1.0'}}
AppPkgCreator
{'Input': {'version': '5.1.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TunesKitM4VConverter/downloads/TunesKit M4V Converter.dmg
AppPkgCreator: Using path '/private/tmp/dmg.atBtaY/TunesKit M4V Converter.app' matched from globbed '/private/tmp/dmg.atBtaY/*.app'.
AppPkgCreator: BundleID: com.tuneskit.m4vconverter
AppPkgCreator: Copied /private/tmp/dmg.atBtaY/TunesKit M4V Converter.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TunesKitM4VConverter/payload/Applications/TunesKit M4V Converter.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.tuneskit.m4vconverter',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.TunesKitM4VConverter/TunesKit '
                                                                    'M4V '
                                                                    'Converter-5.1.0.pkg',
                                                        'version': '5.1.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '5.1.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TunesKitM4VConverter/receipts/TunesKit M4V Converter.pkg-receipt-20210213-234126.plist

The following packages were built:
    Identifier                 Version  Pkg Path                                                                                                             
    ----------                 -------  --------                                                                                                             
    com.tuneskit.m4vconverter  5.1.0    ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TunesKitM4VConverter/TunesKit M4V Converter-5.1.0.pkg  
```

## ✅ Jakob Egger/Table Tool.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Jakob\ Egger/Table\ Tool.pkg.recipe
Processing repos/macprince-recipes/Jakob Egger/Table Tool.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'jakob/TableTool'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'tabletool-1.2.1.zip' from release 'Table Tool 1.2.1'
{'Output': {'release_notes': '- fix an issue where files with an unrecognised '
                             'format could not be opened #42\r\n'
                             '- fix an issue where Table Tool did not work on '
                             'older versions of macOS #14\r\n',
            'url': 'https://github.com/jakob/TableTool/releases/download/v1.2.1/tabletool-1.2.1.zip',
            'version': '1.2.1'}}
URLDownloader
{'Input': {'filename': 'Table Tool-1.2.1.tgz',
           'url': 'https://github.com/jakob/TableTool/releases/download/v1.2.1/tabletool-1.2.1.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/downloads/Table Tool-1.2.1.tgz
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/downloads/Table '
                        'Tool-1.2.1.tgz'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/downloads/Table '
                           'Tool-1.2.1.tgz',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/Table '
                               'Tool',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'tar_gzip' from filename Table Tool-1.2.1.tgz
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/downloads/Table Tool-1.2.1.tgz to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/Table Tool
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/Table '
                         'Tool/Table Tool.app',
           'requirement': 'anchor apple generic and identifier '
                          '"at.eggerapps.tabletool" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = ZF84SJ5A3G)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/Table Tool/Table Tool.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/Table Tool/Table Tool.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/Table Tool/Table Tool.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/Table '
                               'Tool/Table Tool.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 1.2.1 in file ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/Table Tool/Table Tool.app/Contents/Info.plist
{'Output': {'version': '1.2.1'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/Table '
                       'Tool/Table Tool.app',
           'version': '1.2.1'}}
AppPkgCreator: BundleID: at.eggerapps.tabletool
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/Table Tool/Table Tool.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/payload/Applications/Table Tool.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'at.eggerapps.tabletool',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/Table '
                                                                    'Tool-1.2.1.pkg',
                                                        'version': '1.2.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.2.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/receipts/Table Tool.pkg-receipt-20210213-234129.plist

The following packages were built:
    Identifier              Version  Pkg Path                                                                                      
    ----------              -------  --------                                                                                      
    at.eggerapps.tabletool  1.2.1    ~/Library/AutoPkg/Cache/com.github.macprince.pkg.TableTool/Table Tool-1.2.1.pkg  
```

## ✅ Kuta Software/Infinite Algebra 1.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Kuta\ Software/Infinite\ Algebra\ 1.pkg.recipe
Processing repos/macprince-recipes/Kuta Software/Infinite Algebra 1.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; '
                                                     'Intel Mac OS X 10_13_6) '
                                                     'AppleWebKit/537.36 '
                                                     '(KHTML, like Gecko) '
                                                     'Chrome/74.0.3729.131 '
                                                     'Safari/537.36'},
           'appcast_url': 'https://www.kutasoftware.com/updates/appcast_a1m.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.52.00
SparkleUpdateInfoProvider: Found URL https://cdn.kutasoftware.com/retail/mac/IA1-Site-2.52.00.dmg
{'Output': {'url': 'https://cdn.kutasoftware.com/retail/mac/IA1-Site-2.52.00.dmg',
            'version': '2.52.00'}}
URLDownloader
{'Input': {'filename': 'Infinite Algebra 1-2.52.00.dmg',
           'url': 'https://cdn.kutasoftware.com/retail/mac/IA1-Site-2.52.00.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra1/downloads/Infinite Algebra 1-2.52.00.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra1/downloads/Infinite '
                        'Algebra 1-2.52.00.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra1/downloads/Infinite '
                         'Algebra 1-2.52.00.dmg/Infinite Algebra 1.app',
           'requirement': 'identifier "com.kutasoftware.InfiniteAlgebra1" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2XHJ678JT7"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra1/downloads/Infinite Algebra 1-2.52.00.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.Bcli5p/Infinite Algebra 1.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.Bcli5p/Infinite Algebra 1.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.Bcli5p/Infinite Algebra 1.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2.52.00'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra1/downloads/Infinite Algebra 1-2.52.00.dmg
AppPkgCreator: Using path '/private/tmp/dmg.MJcmbk/Infinite Algebra 1.app' matched from globbed '/private/tmp/dmg.MJcmbk/*.app'.
AppPkgCreator: BundleID: com.kutasoftware.InfiniteAlgebra1
AppPkgCreator: Copied /private/tmp/dmg.MJcmbk/Infinite Algebra 1.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra1/payload/Applications/Infinite Algebra 1.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.kutasoftware.InfiniteAlgebra1',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra1/Infinite '
                                                                    'Algebra '
                                                                    '1-2.52.00.pkg',
                                                        'version': '2.52.00'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.52.00'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra1/receipts/Infinite Algebra 1.pkg-receipt-20210213-234146.plist

The following packages were built:
    Identifier                         Version  Pkg Path                                                                                                       
    ----------                         -------  --------                                                                                                       
    com.kutasoftware.InfiniteAlgebra1  2.52.00  ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra1/Infinite Algebra 1-2.52.00.pkg  
```

## ✅ Kuta Software/Infinite Algebra 2.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Kuta\ Software/Infinite\ Algebra\ 2.pkg.recipe
Processing repos/macprince-recipes/Kuta Software/Infinite Algebra 2.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; '
                                                     'Intel Mac OS X 10_13_6) '
                                                     'AppleWebKit/537.36 '
                                                     '(KHTML, like Gecko) '
                                                     'Chrome/74.0.3729.131 '
                                                     'Safari/537.36'},
           'appcast_url': 'https://www.kutasoftware.com/updates/appcast_a2m.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.52.00
SparkleUpdateInfoProvider: Found URL https://cdn.kutasoftware.com/retail/mac/IA2-Site-2.52.00.dmg
{'Output': {'url': 'https://cdn.kutasoftware.com/retail/mac/IA2-Site-2.52.00.dmg',
            'version': '2.52.00'}}
URLDownloader
{'Input': {'filename': 'Infinite Algebra 2-2.52.00.dmg',
           'url': 'https://cdn.kutasoftware.com/retail/mac/IA2-Site-2.52.00.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra2/downloads/Infinite Algebra 2-2.52.00.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra2/downloads/Infinite '
                        'Algebra 2-2.52.00.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra2/downloads/Infinite '
                         'Algebra 2-2.52.00.dmg/Infinite Algebra 2.app',
           'requirement': 'identifier "com.kutasoftware.InfiniteAlgebra2" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2XHJ678JT7"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra2/downloads/Infinite Algebra 2-2.52.00.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.RvfN5D/Infinite Algebra 2.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.RvfN5D/Infinite Algebra 2.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.RvfN5D/Infinite Algebra 2.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2.52.00'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra2/downloads/Infinite Algebra 2-2.52.00.dmg
AppPkgCreator: Using path '/private/tmp/dmg.YIxTUj/Infinite Algebra 2.app' matched from globbed '/private/tmp/dmg.YIxTUj/*.app'.
AppPkgCreator: BundleID: com.kutasoftware.InfiniteAlgebra2
AppPkgCreator: Copied /private/tmp/dmg.YIxTUj/Infinite Algebra 2.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra2/payload/Applications/Infinite Algebra 2.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.kutasoftware.InfiniteAlgebra2',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra2/Infinite '
                                                                    'Algebra '
                                                                    '2-2.52.00.pkg',
                                                        'version': '2.52.00'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.52.00'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra2/receipts/Infinite Algebra 2.pkg-receipt-20210213-234204.plist

The following packages were built:
    Identifier                         Version  Pkg Path                                                                                                       
    ----------                         -------  --------                                                                                                       
    com.kutasoftware.InfiniteAlgebra2  2.52.00  ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteAlgebra2/Infinite Algebra 2-2.52.00.pkg  
```

## ✅ Kuta Software/Infinite Calculus.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Kuta\ Software/Infinite\ Calculus.pkg.recipe
Processing repos/macprince-recipes/Kuta Software/Infinite Calculus.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; '
                                                     'Intel Mac OS X 10_13_6) '
                                                     'AppleWebKit/537.36 '
                                                     '(KHTML, like Gecko) '
                                                     'Chrome/74.0.3729.131 '
                                                     'Safari/537.36'},
           'appcast_url': 'https://www.kutasoftware.com/updates/appcast_cam.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.52.00
SparkleUpdateInfoProvider: Found URL https://cdn.kutasoftware.com/retail/mac/ICA-Site-2.52.00.dmg
{'Output': {'url': 'https://cdn.kutasoftware.com/retail/mac/ICA-Site-2.52.00.dmg',
            'version': '2.52.00'}}
URLDownloader
{'Input': {'filename': 'Infinite Calculus-2.52.00.dmg',
           'url': 'https://cdn.kutasoftware.com/retail/mac/ICA-Site-2.52.00.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteCalculus/downloads/Infinite Calculus-2.52.00.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteCalculus/downloads/Infinite '
                        'Calculus-2.52.00.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteCalculus/downloads/Infinite '
                         'Calculus-2.52.00.dmg/Infinite Calculus.app',
           'requirement': 'identifier "com.kutasoftware.InfiniteCalculus" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2XHJ678JT7"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteCalculus/downloads/Infinite Calculus-2.52.00.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.k9ENT4/Infinite Calculus.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.k9ENT4/Infinite Calculus.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.k9ENT4/Infinite Calculus.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2.52.00'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteCalculus/downloads/Infinite Calculus-2.52.00.dmg
AppPkgCreator: Using path '/private/tmp/dmg.2xwCo0/Infinite Calculus.app' matched from globbed '/private/tmp/dmg.2xwCo0/*.app'.
AppPkgCreator: BundleID: com.kutasoftware.InfiniteCalculus
AppPkgCreator: Copied /private/tmp/dmg.2xwCo0/Infinite Calculus.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteCalculus/payload/Applications/Infinite Calculus.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.kutasoftware.InfiniteCalculus',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteCalculus/Infinite '
                                                                    'Calculus-2.52.00.pkg',
                                                        'version': '2.52.00'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.52.00'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteCalculus/receipts/Infinite Calculus.pkg-receipt-20210213-234222.plist

The following packages were built:
    Identifier                         Version  Pkg Path                                                                                                      
    ----------                         -------  --------                                                                                                      
    com.kutasoftware.InfiniteCalculus  2.52.00  ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteCalculus/Infinite Calculus-2.52.00.pkg  
```

## ✅ Kuta Software/Infinite Geometry.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Kuta\ Software/Infinite\ Geometry.pkg.recipe
Processing repos/macprince-recipes/Kuta Software/Infinite Geometry.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; '
                                                     'Intel Mac OS X 10_13_6) '
                                                     'AppleWebKit/537.36 '
                                                     '(KHTML, like Gecko) '
                                                     'Chrome/74.0.3729.131 '
                                                     'Safari/537.36'},
           'appcast_url': 'https://www.kutasoftware.com/updates/appcast_gem.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.52.00
SparkleUpdateInfoProvider: Found URL https://cdn.kutasoftware.com/retail/mac/IGE-Site-2.52.00.dmg
{'Output': {'url': 'https://cdn.kutasoftware.com/retail/mac/IGE-Site-2.52.00.dmg',
            'version': '2.52.00'}}
URLDownloader
{'Input': {'filename': 'Infinite Geometry-2.52.00.dmg',
           'url': 'https://cdn.kutasoftware.com/retail/mac/IGE-Site-2.52.00.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteGeometry/downloads/Infinite Geometry-2.52.00.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteGeometry/downloads/Infinite '
                        'Geometry-2.52.00.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteGeometry/downloads/Infinite '
                         'Geometry-2.52.00.dmg/Infinite Geometry.app',
           'requirement': 'identifier "com.kutasoftware.InfiniteGeometry" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2XHJ678JT7"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteGeometry/downloads/Infinite Geometry-2.52.00.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.zQ06Xm/Infinite Geometry.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.zQ06Xm/Infinite Geometry.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.zQ06Xm/Infinite Geometry.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2.52.00'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteGeometry/downloads/Infinite Geometry-2.52.00.dmg
AppPkgCreator: Using path '/private/tmp/dmg.GJBEJZ/Infinite Geometry.app' matched from globbed '/private/tmp/dmg.GJBEJZ/*.app'.
AppPkgCreator: BundleID: com.kutasoftware.InfiniteGeometry
AppPkgCreator: Copied /private/tmp/dmg.GJBEJZ/Infinite Geometry.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteGeometry/payload/Applications/Infinite Geometry.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.kutasoftware.InfiniteGeometry',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteGeometry/Infinite '
                                                                    'Geometry-2.52.00.pkg',
                                                        'version': '2.52.00'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.52.00'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteGeometry/receipts/Infinite Geometry.pkg-receipt-20210213-234238.plist

The following packages were built:
    Identifier                         Version  Pkg Path                                                                                                      
    ----------                         -------  --------                                                                                                      
    com.kutasoftware.InfiniteGeometry  2.52.00  ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfiniteGeometry/Infinite Geometry-2.52.00.pkg  
```

## ✅ Kuta Software/Infinite Pre-Algebra.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Kuta\ Software/Infinite\ Pre-Algebra.pkg.recipe
Processing repos/macprince-recipes/Kuta Software/Infinite Pre-Algebra.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; '
                                                     'Intel Mac OS X 10_13_6) '
                                                     'AppleWebKit/537.36 '
                                                     '(KHTML, like Gecko) '
                                                     'Chrome/74.0.3729.131 '
                                                     'Safari/537.36'},
           'appcast_url': 'https://www.kutasoftware.com/updates/appcast_pam.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.52.00
SparkleUpdateInfoProvider: Found URL https://cdn.kutasoftware.com/retail/mac/IPA-Site-2.52.00.dmg
{'Output': {'url': 'https://cdn.kutasoftware.com/retail/mac/IPA-Site-2.52.00.dmg',
            'version': '2.52.00'}}
URLDownloader
{'Input': {'filename': 'Infinite Pre-Algebra-2.52.00.dmg',
           'url': 'https://cdn.kutasoftware.com/retail/mac/IPA-Site-2.52.00.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePre-Algebra/downloads/Infinite Pre-Algebra-2.52.00.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePre-Algebra/downloads/Infinite '
                        'Pre-Algebra-2.52.00.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePre-Algebra/downloads/Infinite '
                         'Pre-Algebra-2.52.00.dmg/Infinite Pre-Algebra.app',
           'requirement': 'identifier "com.kutasoftware.InfinitePreAlgebra" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2XHJ678JT7"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePre-Algebra/downloads/Infinite Pre-Algebra-2.52.00.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.lHAAMF/Infinite Pre-Algebra.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.lHAAMF/Infinite Pre-Algebra.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.lHAAMF/Infinite Pre-Algebra.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2.52.00'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePre-Algebra/downloads/Infinite Pre-Algebra-2.52.00.dmg
AppPkgCreator: Using path '/private/tmp/dmg.tSbAHH/Infinite Pre-Algebra.app' matched from globbed '/private/tmp/dmg.tSbAHH/*.app'.
AppPkgCreator: BundleID: com.kutasoftware.InfinitePreAlgebra
AppPkgCreator: Copied /private/tmp/dmg.tSbAHH/Infinite Pre-Algebra.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePre-Algebra/payload/Applications/Infinite Pre-Algebra.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.kutasoftware.InfinitePreAlgebra',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePre-Algebra/Infinite '
                                                                    'Pre-Algebra-2.52.00.pkg',
                                                        'version': '2.52.00'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.52.00'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePre-Algebra/receipts/Infinite Pre-Algebra.pkg-receipt-20210213-234253.plist

The following packages were built:
    Identifier                           Version  Pkg Path                                                                                                            
    ----------                           -------  --------                                                                                                            
    com.kutasoftware.InfinitePreAlgebra  2.52.00  ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePre-Algebra/Infinite Pre-Algebra-2.52.00.pkg  
```

## ✅ Kuta Software/Infinite Precalculus.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Kuta\ Software/Infinite\ Precalculus.pkg.recipe
Processing repos/macprince-recipes/Kuta Software/Infinite Precalculus.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_request_headers': {'User-Agent': 'Mozilla/5.0 (Macintosh; '
                                                     'Intel Mac OS X 10_13_6) '
                                                     'AppleWebKit/537.36 '
                                                     '(KHTML, like Gecko) '
                                                     'Chrome/74.0.3729.131 '
                                                     'Safari/537.36'},
           'appcast_url': 'https://www.kutasoftware.com/updates/appcast_pcm.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.52.00
SparkleUpdateInfoProvider: Found URL https://cdn.kutasoftware.com/retail/mac/IPC-Site-2.52.00.dmg
{'Output': {'url': 'https://cdn.kutasoftware.com/retail/mac/IPC-Site-2.52.00.dmg',
            'version': '2.52.00'}}
URLDownloader
{'Input': {'filename': 'Infinite Precalculus-2.52.00.dmg',
           'url': 'https://cdn.kutasoftware.com/retail/mac/IPC-Site-2.52.00.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePrecalculus/downloads/Infinite Precalculus-2.52.00.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePrecalculus/downloads/Infinite '
                        'Precalculus-2.52.00.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePrecalculus/downloads/Infinite '
                         'Precalculus-2.52.00.dmg/Infinite Precalculus.app',
           'requirement': 'identifier "com.kutasoftware.InfinitePrecalculus" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2XHJ678JT7"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePrecalculus/downloads/Infinite Precalculus-2.52.00.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.yESn0i/Infinite Precalculus.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.yESn0i/Infinite Precalculus.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.yESn0i/Infinite Precalculus.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2.52.00'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePrecalculus/downloads/Infinite Precalculus-2.52.00.dmg
AppPkgCreator: Using path '/private/tmp/dmg.4rxG2t/Infinite Precalculus.app' matched from globbed '/private/tmp/dmg.4rxG2t/*.app'.
AppPkgCreator: BundleID: com.kutasoftware.InfinitePrecalculus
AppPkgCreator: Copied /private/tmp/dmg.4rxG2t/Infinite Precalculus.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePrecalculus/payload/Applications/Infinite Precalculus.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.kutasoftware.InfinitePrecalculus',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePrecalculus/Infinite '
                                                                    'Precalculus-2.52.00.pkg',
                                                        'version': '2.52.00'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.52.00'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePrecalculus/receipts/Infinite Precalculus.pkg-receipt-20210213-234311.plist

The following packages were built:
    Identifier                            Version  Pkg Path                                                                                                            
    ----------                            -------  --------                                                                                                            
    com.kutasoftware.InfinitePrecalculus  2.52.00  ~/Library/AutoPkg/Cache/com.github.macprince.pkg.InfinitePrecalculus/Infinite Precalculus-2.52.00.pkg  
```

## ✅ Michael Herrmann/fman.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Michael\ Herrmann/fman.pkg.recipe
Processing repos/macprince-recipes/Michael Herrmann/fman.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://fman.io/updates/Appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1.7.3
SparkleUpdateInfoProvider: Found URL https://fman.io/updates/mac/1.7.3.zip
{'Output': {'url': 'https://fman.io/updates/mac/1.7.3.zip', 'version': '1.7.3'}}
URLDownloader
{'Input': {'filename': 'fman-1.7.3.zip',
           'url': 'https://fman.io/updates/mac/1.7.3.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/downloads/fman-1.7.3.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/downloads/fman-1.7.3.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/downloads/fman-1.7.3.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/fman',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename fman-1.7.3.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/downloads/fman-1.7.3.zip to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/fman
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/fman/fman.app',
           'requirement': 'identifier "io.fman.fman" and anchor apple generic '
                          'and certificate 1[field.1.2.840.113635.100.6.2.6] '
                          '/* exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = BWPMY54VTZ'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/fman/fman.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/fman/fman.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/fman/fman.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/fman/fman.app',
           'version': '1.7.3'}}
AppPkgCreator: BundleID: io.fman.fman
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/fman/fman.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/payload/Applications/fman.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'io.fman.fman',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/fman-1.7.3.pkg',
                                                        'version': '1.7.3'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.7.3'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/receipts/fman.pkg-receipt-20210213-234320.plist

The following packages were built:
    Identifier    Version  Pkg Path                                                                           
    ----------    -------  --------                                                                           
    io.fman.fman  1.7.3    ~/Library/AutoPkg/Cache/com.github.macprince.pkg.fman/fman-1.7.3.pkg  
```

## ✅ Nindi Gill/MacUserGenerator.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Nindi\ Gill/MacUserGenerator.pkg.recipe
Processing repos/macprince-recipes/Nindi Gill/MacUserGenerator.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'ninxsoft/MacUserGenerator'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'MacUserGenerator-0.3.dmg' from release 'MacUserGenerator 0.3'
{'Output': {'release_notes': '- Export script rewritten in **Python**\r\n'
                             '  - Home directory is now created correctly '
                             '(#3)\r\n'
                             '  - Full support for macOS Mojave **10.14**! '
                             '(#5, #7, #11 and #12)\r\n'
                             '  - User account creation will abort if '
                             '**username** or **uid** already exists (#9)\r\n'
                             '- Dark appearance support\r\n'
                             '- Removed all unnecessary Setup Assistant '
                             'checkboxes\r\n'
                             '- Full name conversion to account no longer '
                             'capitalises (#4)\r\n'
                             '- A new UUID is generated every time the '
                             'exported package / script is run (#8)\r\n'
                             '- Xcode project updated to support Swift 5.0',
            'url': 'https://github.com/ninxsoft/MacUserGenerator/releases/download/v0.3/MacUserGenerator-0.3.dmg',
            'version': '0.3'}}
URLDownloader
{'Input': {'filename': 'MacUserGenerator-0.3.dmg',
           'url': 'https://github.com/ninxsoft/MacUserGenerator/releases/download/v0.3/MacUserGenerator-0.3.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.MacUserGenerator/downloads/MacUserGenerator-0.3.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.MacUserGenerator/downloads/MacUserGenerator-0.3.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.MacUserGenerator/downloads/MacUserGenerator-0.3.dmg/MacUserGenerator.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.ninxsoft.MacUserGenerator" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "7K3HVCLV7Z")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.MacUserGenerator/downloads/MacUserGenerator-0.3.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.z2iOWl/MacUserGenerator.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.z2iOWl/MacUserGenerator.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.z2iOWl/MacUserGenerator.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.MacUserGenerator/downloads/MacUserGenerator-0.3.dmg/MacUserGenerator.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.MacUserGenerator/downloads/MacUserGenerator-0.3.dmg
Versioner: Found version 0.3 in file /private/tmp/dmg.sdbBuy/MacUserGenerator.app/Contents/Info.plist
{'Output': {'version': '0.3'}}
AppPkgCreator
{'Input': {'version': '0.3'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.MacUserGenerator/downloads/MacUserGenerator-0.3.dmg
AppPkgCreator: Using path '/private/tmp/dmg.xJNiEF/MacUserGenerator.app' matched from globbed '/private/tmp/dmg.xJNiEF/*.app'.
AppPkgCreator: BundleID: com.ninxsoft.MacUserGenerator
AppPkgCreator: Copied /private/tmp/dmg.xJNiEF/MacUserGenerator.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.MacUserGenerator/payload/Applications/MacUserGenerator.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.ninxsoft.MacUserGenerator',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.MacUserGenerator/MacUserGenerator-0.3.pkg',
                                                        'version': '0.3'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '0.3'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.MacUserGenerator/receipts/MacUserGenerator.pkg-receipt-20210213-234336.plist

The following packages were built:
    Identifier                     Version  Pkg Path                                                                                                 
    ----------                     -------  --------                                                                                                 
    com.ninxsoft.MacUserGenerator  0.3      ~/Library/AutoPkg/Cache/com.github.macprince.pkg.MacUserGenerator/MacUserGenerator-0.3.pkg  
```

## ✅ Sonarr/Sonarr.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Sonarr/Sonarr.pkg.recipe
Processing repos/macprince-recipes/Sonarr/Sonarr.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Sonarr.zip',
           'url': 'https://download.sonarr.tv/v2/master/latest/NzbDrone.master.osx.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Sonarr/downloads/Sonarr.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.Sonarr/downloads/Sonarr.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.Sonarr/downloads/Sonarr.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.Sonarr/Sonarr',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Sonarr.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Sonarr/downloads/Sonarr.zip to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Sonarr/Sonarr
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.Sonarr/Sonarr/Sonarr.app'}}
AppPkgCreator: Version: 2.0
AppPkgCreator: BundleID: com.osx.sonarr.tv
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Sonarr/Sonarr/Sonarr.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Sonarr/payload/Applications/Sonarr.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.osx.sonarr.tv',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.Sonarr/Sonarr-2.0.pkg',
                                                        'version': '2.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Sonarr/receipts/Sonarr.pkg-receipt-20210213-234342.plist

The following packages were built:
    Identifier         Version  Pkg Path                                                                             
    ----------         -------  --------                                                                             
    com.osx.sonarr.tv  2.0      ~/Library/AutoPkg/Cache/com.github.macprince.pkg.Sonarr/Sonarr-2.0.pkg  
```

## ✅ Tran Ky Nam/aText.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Tran\ Ky\ Nam/aText.pkg.recipe
Processing repos/macprince-recipes/Tran Ky Nam/aText.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.trankynam.com/atext/aText-Appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 104
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.36.6
SparkleUpdateInfoProvider: Found URL https://www.trankynam.com/atext/downloads/aText.dmg
{'Output': {'url': 'https://www.trankynam.com/atext/downloads/aText.dmg',
            'version': '2.36.6'}}
URLDownloader
{'Input': {'filename': 'aText-2.36.6.dmg',
           'url': 'https://www.trankynam.com/atext/downloads/aText.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.aText/downloads/aText-2.36.6.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.aText/downloads/aText-2.36.6.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.aText/downloads/aText-2.36.6.dmg/aText.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.trankynam.aText" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = KHEMQ2FD9E)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.aText/downloads/aText-2.36.6.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.zW66Xi/aText.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.zW66Xi/aText.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.zW66Xi/aText.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2.36.6'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.aText/downloads/aText-2.36.6.dmg
AppPkgCreator: Using path '/private/tmp/dmg.98qMkf/aText.app' matched from globbed '/private/tmp/dmg.98qMkf/*.app'.
AppPkgCreator: BundleID: com.trankynam.aText
AppPkgCreator: Copied /private/tmp/dmg.98qMkf/aText.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.aText/payload/Applications/aText.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.trankynam.aText',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.aText/aText-2.36.6.pkg',
                                                        'version': '2.36.6'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.36.6'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.aText/receipts/aText.pkg-receipt-20210213-234350.plist

The following packages were built:
    Identifier           Version  Pkg Path                                                                              
    ----------           -------  --------                                                                              
    com.trankynam.aText  2.36.6   ~/Library/AutoPkg/Cache/com.github.macprince.pkg.aText/aText-2.36.6.pkg  
```

## ✅ Vital Source Technologies/VitalSource Bookshelf.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/macprince-recipes/Vital\ Source\ Technologies/VitalSource\ Bookshelf.pkg.recipe
Processing repos/macprince-recipes/Vital Source Technologies/VitalSource Bookshelf.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(?P<DOWNLOAD_URL>https:.*.dmg)',
           'url': 'https://support.vitalsource.com/hc/en-us/articles/360014107913'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (DOWNLOAD_URL): https://downloads.vitalbook.com/vsti/bookshelf/9.4.3/mac/bookshelf/VitalSource-Bookshelf_9.4.3.1330.dmg
URLTextSearcher: Found matching text (match): https://downloads.vitalbook.com/vsti/bookshelf/9.4.3/mac/bookshelf/VitalSource-Bookshelf_9.4.3.1330.dmg
{'Output': {'DOWNLOAD_URL': 'https://downloads.vitalbook.com/vsti/bookshelf/9.4.3/mac/bookshelf/VitalSource-Bookshelf_9.4.3.1330.dmg',
            'match': 'https://downloads.vitalbook.com/vsti/bookshelf/9.4.3/mac/bookshelf/VitalSource-Bookshelf_9.4.3.1330.dmg'}}
URLDownloader
{'Input': {'filename': 'VitalSource Bookshelf.dmg',
           'url': 'https://downloads.vitalbook.com/vsti/bookshelf/9.4.3/mac/bookshelf/VitalSource-Bookshelf_9.4.3.1330.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VitalSourceBookshelf/downloads/VitalSource Bookshelf.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.VitalSourceBookshelf/downloads/VitalSource '
                        'Bookshelf.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.VitalSourceBookshelf/downloads/VitalSource '
                         'Bookshelf.dmg/VitalSource Bookshelf.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.vitalsource.bookshelf" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = QX549BPYZU)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VitalSourceBookshelf/downloads/VitalSource Bookshelf.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.qRrpOm/VitalSource Bookshelf.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.qRrpOm/VitalSource Bookshelf.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.qRrpOm/VitalSource Bookshelf.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.VitalSourceBookshelf/downloads/VitalSource '
                               'Bookshelf.dmg/VitalSource '
                               'Bookshelf.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VitalSourceBookshelf/downloads/VitalSource Bookshelf.dmg
Versioner: Found version 9.4.3 in file /private/tmp/dmg.NrLzEn/VitalSource Bookshelf.app/Contents/Info.plist
{'Output': {'version': '9.4.3'}}
AppPkgCreator
{'Input': {'version': '9.4.3'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VitalSourceBookshelf/downloads/VitalSource Bookshelf.dmg
AppPkgCreator: Using path '/private/tmp/dmg.qedh7B/VitalSource Bookshelf.app' matched from globbed '/private/tmp/dmg.qedh7B/*.app'.
AppPkgCreator: BundleID: com.vitalsource.bookshelf
AppPkgCreator: Copied /private/tmp/dmg.qedh7B/VitalSource Bookshelf.app to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VitalSourceBookshelf/payload/Applications/VitalSource Bookshelf.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.vitalsource.bookshelf',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.macprince.pkg.VitalSourceBookshelf/VitalSource '
                                                                    'Bookshelf-9.4.3.pkg',
                                                        'version': '9.4.3'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '9.4.3'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VitalSourceBookshelf/receipts/VitalSource Bookshelf.pkg-receipt-20210213-234434.plist

The following packages were built:
    Identifier                 Version  Pkg Path                                                                                                            
    ----------                 -------  --------                                                                                                            
    com.vitalsource.bookshelf  9.4.3    ~/Library/AutoPkg/Cache/com.github.macprince.pkg.VitalSourceBookshelf/VitalSource Bookshelf-9.4.3.pkg  
```

