### PR TITLE
Move VitalSource Bookshelf download recipe to SparkleUpdateInfoProvider

### DIFF
--- a/Vital Source Technologies/VitalSource Bookshelf.download.recipe
+++ b/Vital Source Technologies/VitalSource Bookshelf.download.recipe
@@ -10,7 +10,7 @@
 	<string>com.github.macprince.download.VitalSourceBookshelf</string>
 	<key>Input</key>
 	<dict>
-		<key>SEARCH_URL</key>
+		<key>FEED_URL</key>
 		<string>https://api.vitalsource.com/v3/versions/check</string>
 		<key>USER_AGENT</key>
 		<string>VitalSource Bookshelf/10.0.0 (Mac OS/Version 10.15.7 (Build 19H1419); en-US) Sparkle/1.0</string>
@@ -23,14 +23,12 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>SparkleUpdateInfoProvider</string>
 			<key>Arguments</key>
 			<dict>
-				<key>re_pattern</key>
-				<string>(?P&lt;DOWNLOAD_URL&gt;https:.*.dmg)</string>
-				<key>url</key>
-				<string>%SEARCH_URL%</string>
-				<key>request_headers</key>
+				<key>appcast_url</key>
+				<string>%FEED_URL%</string>
+				<key>appcast_request_headers</key>
 				<dict>
 					<key>user-agent</key>
 					<string>%USER_AGENT%</string>
@@ -42,8 +40,6 @@
 			<dict>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Apparently the update feed for VitalSource Bookshelf is actually a valid Sparkle feed. Less URLTextSearcher and regex is always a good thing...