### PR TITLE
Adjust Beamer recipes for new download URL and dmg format

### DIFF
--- a/Tupil/Beamer.download.recipe
+++ b/Tupil/Beamer.download.recipe
@@ -20,17 +20,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://beamer-app.com/beamer3-appcast.xml</string>
-			</dict>
-			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
+				<string>%NAME%.dmg</string>
+				<key>url</key>
+				<string>https://ushining.softorino.com/download.php?abbr=bmrm</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -42,23 +35,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Beamer.app</string>
+				<string>%pathname%/Beamer.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.tupil.beamer" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7AGB5PZAP3")</string>
+				<string>anchor apple generic and identifier "com.softorino.beamer" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7D85YS7677")</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Tupil/Beamer.install.recipe
+++ b/Tupil/Beamer.install.recipe
@@ -23,18 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>items_to_copy</key>
 				<array>
 					<dict>

--- a/Tupil/Beamer.munki.recipe
+++ b/Tupil/Beamer.munki.recipe
@@ -43,19 +43,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Tupil/Beamer.pkg.recipe
+++ b/Tupil/Beamer.pkg.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Beamer.app</string>
+				<string>%pathname%/Beamer.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>


### PR DESCRIPTION
This PR adjusts the Beamer recipes to use a new download URL which provides a dmg.

Verbose recipe run output:

```
% autopkg run -vvq 'Tupil/Beamer.download.recipe'
Processing Tupil/Beamer.download.recipe...
WARNING: Tupil/Beamer.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Beamer.dmg',
           'url': 'https://ushining.softorino.com/download.php?abbr=bmrm'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 28 Aug 2023 08:12:51 GMT
URLDownloader: Storing new ETag header: "s03dhf8lx5r"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.macprince.download.Beamer/downloads/Beamer.dmg
{'Output': {'download_changed': True,
            'etag': '"s03dhf8lx5r"',
            'last_modified': 'Mon, 28 Aug 2023 08:12:51 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.download.Beamer/downloads/Beamer.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.macprince.download.Beamer/downloads/Beamer.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.download.Beamer/downloads/Beamer.dmg/Beamer.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.softorino.beamer" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "7D85YS7677")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.download.Beamer/downloads/Beamer.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.uycioV/Beamer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.uycioV/Beamer.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.uycioV/Beamer.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.download.Beamer/receipts/Beamer.download-receipt-20241226-222920.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.macprince.download.Beamer/downloads/Beamer.dmg
```
