### PR TITLE
Add code signature verification for ScummVM

### DIFF
--- a/ScummVM Team/ScummVM.download.recipe
+++ b/ScummVM Team/ScummVM.download.recipe
@@ -41,6 +41,17 @@
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/ScummVM.app</string>
+				<key>requirement</key>
+				<string>identifier "org.scummvm.app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = W5BM726PG6</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Verbose recipe run after change:

```
% autopkg run -vvq 'macprince-recipes/ScummVM Team/ScummVM.download.recipe'
Processing macprince-recipes/ScummVM Team/ScummVM.download.recipe...
WARNING: macprince-recipes/ScummVM Team/ScummVM.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.scummvm.org/appcasts/macosx/release.xml'}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: No value supplied for urlencode_path_component, setting default value of: True
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.9.1
SparkleUpdateInfoProvider: Found URL https://downloads.scummvm.org/frs/scummvm/2.9.1/scummvm-2.9.1-macosx.dmg
{'Output': {'url': 'https://downloads.scummvm.org/frs/scummvm/2.9.1/scummvm-2.9.1-macosx.dmg',
            'version': '2.9.1'}}
URLDownloader
{'Input': {'filename': 'ScummVM-2.9.1.dmg',
           'url': 'https://downloads.scummvm.org/frs/scummvm/2.9.1/scummvm-2.9.1-macosx.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 19 May 2025 21:17:51 GMT
URLDownloader: Storing new ETag header: "8a91aa3-63583aa18d3e7"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.macprince.download.ScummVM/downloads/ScummVM-2.9.1.dmg
{'Output': {'download_changed': True,
            'etag': '"8a91aa3-63583aa18d3e7"',
            'last_modified': 'Mon, 19 May 2025 21:17:51 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.macprince.download.ScummVM/downloads/ScummVM-2.9.1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.macprince.download.ScummVM/downloads/ScummVM-2.9.1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.macprince.download.ScummVM/downloads/ScummVM-2.9.1.dmg/ScummVM.app',
           'requirement': 'identifier "org.scummvm.app" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'W5BM726PG6'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.macprince.download.ScummVM/downloads/ScummVM-2.9.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.Pxf89X/ScummVM.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.Pxf89X/ScummVM.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.Pxf89X/ScummVM.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.macprince.download.ScummVM/receipts/ScummVM.download-receipt-20251108-220318.plist

The following new items were downloaded:
    Download Path                                                                                          
    -------------                                                                                          
    ~/Library/AutoPkg/Cache/com.github.macprince.download.ScummVM/downloads/ScummVM-2.9.1.dmg
```