### PR TITLE
Deprecate Screens recipes

### DIFF
--- a/Edovia/Screens 4.download.recipe
+++ b/Edovia/Screens 4.download.recipe
@@ -14,9 +14,18 @@
 		<string>Screens 4</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Screens recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The Screens recipes in this repo are similar in function to the earlier-created ones in homebysix-recipes. This PR deprecates the recipes in this repo with a message pointing to those.

This consolidation will help simplify search results and lower maintenance effort. Thank you!