### PR TITLE
Download Universal version of Espanso

### DIFF
--- a/Federico Terzi/Espanso.download.recipe
+++ b/Federico Terzi/Espanso.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>asset_regex</key>
-				<string>.*M1\.dmg$</string>
+				<string>.*-Universal\.zip$</string>
 				<key>github_repo</key>
 				<string>espanso/espanso</string>
 			</dict>


### PR DESCRIPTION
The previous recipe would download the Apple Silicon version only, with no option to override. This change downloads the Universal version instead.